### PR TITLE
Fixes for mesh creation / export

### DIFF
--- a/witcher3_tools/CR2W/Types/BlenderMesh.py
+++ b/witcher3_tools/CR2W/Types/BlenderMesh.py
@@ -14,7 +14,7 @@ class CommonData(object):
         self.boneData = BoneData()
         self.w3_DataCache = W3_DataCache()
         
-        self.autohideDistance:float = 200.0
+        self.autohideDistance:float = 20.0
         self.isTwoSided:bool = False
         self.useExtraStreams:bool = False
         self.generalizedMeshRadius:float = 0.0

--- a/witcher3_tools/CR2W/dc_mesh.py
+++ b/witcher3_tools/CR2W/dc_mesh.py
@@ -833,7 +833,7 @@ def load_bin_mesh(filename, keep_lod_meshes = True, keep_proxy_meshes = False):
             #!  FINISH CODE  #
             #
             ##################
-            CData.autohideDistance = chunk.GetVariableByName("autoHideDistance").Value if chunk.GetVariableByName("autoHideDistance") else 200.0
+            CData.autohideDistance = chunk.GetVariableByName("autoHideDistance").Value if chunk.GetVariableByName("autoHideDistance") else 20.0
             CData.isTwoSided = chunk.GetVariableByName("isTwoSided").Value if chunk.GetVariableByName("isTwoSided") else False
             CData.useExtraStreams = chunk.GetVariableByName("useExtraStreams").Value if chunk.GetVariableByName("useExtraStreams") else False
             CData.generalizedMeshRadius = chunk.GetVariableByName("generalizedMeshRadius").Value if chunk.GetVariableByName("generalizedMeshRadius") else 0.0

--- a/witcher3_tools/exporters/export_mesh.py
+++ b/witcher3_tools/exporters/export_mesh.py
@@ -335,6 +335,10 @@ def split_mesh_by_material(mesh_obj):
     if not used_material_indices:
         mesh_copy = mesh_obj.copy()
         mesh_copy.data = src_mesh
+        # Should only expose one material (the used one) in slot 0
+        mesh_copy.data.materials[0] = mesh_copy.data.materials[used_material_indices[0]]
+        while len(mesh_copy.data.materials) > 1:
+            mesh_copy.data.materials.pop(index = -1)
         bpy.context.collection.objects.link(mesh_copy)
         return [mesh_copy]
 

--- a/witcher3_tools/ui/ui_morphs.py
+++ b/witcher3_tools/ui/ui_morphs.py
@@ -316,7 +316,7 @@ class witcherui_MeshSettings(bpy.types.PropertyGroup):
     distance: bpy.props.FloatProperty(default = 0)
     mat_id: bpy.props.IntProperty(default = 0)
     
-    autohideDistance: bpy.props.FloatProperty(default = 200.0,
+    autohideDistance: bpy.props.FloatProperty(default = 20.0,
                         name = "Auto Hide Distance",
                         description = "Hide mesh after this distance")
     isTwoSided: bpy.props.BoolProperty(default = False,


### PR DESCRIPTION
In some instances, some lods inherit the upper lod's material in slot 0, and have the material they actually use in other slots. Forcing the used material in slot 0 fixes the loss of materials on export.

I also changed the default auto hide distance value to 20.0, as it is the game's default. It's better to have that default when processing vanilla meshes using the default value, and when creating new meshes from scratch.